### PR TITLE
Adds ability to dummy-code Timeline; closes #9

### DIFF
--- a/featurex/tests/test_core.py
+++ b/featurex/tests/test_core.py
@@ -3,7 +3,7 @@ from .utils import _get_test_data_path
 from featurex.stimuli.video import VideoStim
 from featurex.extractors.image import FaceDetectionExtractor
 from featurex.export import FSLExporter
-from featurex.core import Timeline
+from featurex.core import Timeline, Value, Event
 from featurex.lazy import extract
 from os.path import join
 import tempfile
@@ -33,3 +33,14 @@ class TestCore(TestCase):
         assert isinstance(results[0], Timeline)
         textfile = join(_get_test_data_path(), 'text', 'scandal.txt')
         results = extract([textfile], ['basicstatsextractorcollection'])
+
+    def test_dummy_code_timeline(self):
+        data = [{'A': 12.0, 'B': 'abc'}, { 'A': 7, 'B': 'def'}, { 'C': 40 }]
+        events = [Event(values=[Value(None, None, x)], duration=1) for x in data]
+        tl = Timeline(events=events, period=1)
+        self.assertEqual(tl.to_df().shape, (5, 4))
+        tl_dummy = tl.dummy_code()
+        self.assertEqual(tl_dummy.to_df().shape, (7, 4))
+        tl = Timeline(events=events, period=1)
+        tl_dummy = tl.dummy_code(string_only=False)
+        self.assertEqual(tl_dummy.to_df().shape, (9, 4))


### PR DESCRIPTION
Instead of implementing the dummy coding at the export step, it's implemented in the Timeline (see Timeline.dummy_code()).