### PR TITLE
Moving extractors to converters

### DIFF
--- a/featurex/converters/api.py
+++ b/featurex/converters/api.py
@@ -1,6 +1,8 @@
 import os
-from featurex.stimuli.text import ComplexTextStim
+from featurex.stimuli.text import TextStim, ComplexTextStim
 from featurex.converters.audio import AudioToTextConverter
+from featurex.converters.image import ImageToTextConverter
+from PIL import Image
 
 try:
     import speech_recognition as sr
@@ -9,7 +11,7 @@ except ImportError:
 
 
 class SpeechRecognitionConverter(AudioToTextConverter):
-    ''' Uses the SpeechRecognition API, which interacts with several APIs 
+    ''' Uses the SpeechRecognition API, which interacts with several APIs, 
     like Google and Wit, to run speech-to-text transcription on an audio file.
     Args:
         api_key (str): API key. Must be passed explicitly or stored in
@@ -44,3 +46,14 @@ class GoogleSpeechAPIConverter(SpeechRecognitionConverter):
     environ_key = 'GOOGLE_API_KEY'
     recognize_method = 'recognize_google'
 
+
+class TesseractAPIConverter(ImageToTextConverter):
+    ''' Uses the Tesseract library to extract text from images '''
+
+    def __init__(self):
+        super(self.__class__, self).__init__()
+
+    def _convert(self, image):
+        import pytesseract
+        text = pytesseract.image_to_string(Image.fromarray(image.data))
+        return TextStim(text=text)

--- a/featurex/converters/google.py
+++ b/featurex/converters/google.py
@@ -1,0 +1,41 @@
+import argparse
+import base64
+import os
+import re
+import sys
+from featurex.converters.image import ImageToTextConverter
+from featurex.converters import Converter
+from featurex.stimuli.image import ImageStim
+from featurex.stimuli.text import TextStim
+from featurex.google import GoogleVisionAPITransformer
+from featurex import Value, Event
+import tempfile
+from scipy.misc import imsave
+import numpy as np
+
+try:
+    from googleapiclient import discovery, errors
+    from oauth2client.client import GoogleCredentials
+except ImportError:
+    pass
+
+
+class GoogleVisionAPITextConverter(GoogleVisionAPITransformer, ImageToTextConverter):
+
+    request_type = 'TEXT_DETECTION'
+    response_object = 'textAnnotations'
+
+    def _convert(self, stim):
+        request =  self._build_request([stim])
+        responses = self._query_api(request)
+        response = responses[0]
+
+        if response:
+            annotations = response[self.response_object]
+            # Concatenate all the annotation
+            text = ''
+            for annotation in annotations:
+                text += annotation['description']
+            return TextStim(text=text)
+        else:
+            return TextStim(text='')

--- a/featurex/converters/google.py
+++ b/featurex/converters/google.py
@@ -25,6 +25,12 @@ class GoogleVisionAPITextConverter(GoogleVisionAPITransformer, ImageToTextConver
     request_type = 'TEXT_DETECTION'
     response_object = 'textAnnotations'
 
+
+    def __init__(self, handle_annotations='first', **kwargs):
+        super(GoogleVisionAPITextConverter, self).__init__(**kwargs)
+        self.handle_annotations = handle_annotations
+
+
     def _convert(self, stim):
         request =  self._build_request([stim])
         responses = self._query_api(request)
@@ -32,10 +38,20 @@ class GoogleVisionAPITextConverter(GoogleVisionAPITransformer, ImageToTextConver
 
         if response:
             annotations = response[self.response_object]
-            # Concatenate all the annotation
-            text = ''
-            for annotation in annotations:
-                text += annotation['description']
-            return TextStim(text=text)
+            # Combine the annotations
+            if self.handle_annotations == 'first':
+                text = annotations[0]['description']
+                return TextStim(text=text)
+            elif self.handle_annotations == 'concatenate':
+                text = ''
+                for annotation in annotations:
+                    text += annotation['description']
+                return TextStim(text=text)
+            elif self.handle_annotations == 'list':
+                texts = []
+                for annotation in annotations:
+                    texts.append(TextStim(text=annotation['description']))
+                return texts
+            
         else:
             return TextStim(text='')

--- a/featurex/converters/image.py
+++ b/featurex/converters/image.py
@@ -1,0 +1,10 @@
+from featurex.stimuli.image import ImageStim
+from featurex.stimuli.text import TextStim
+from featurex.converters import Converter
+
+class ImageToTextConverter(Converter):
+
+    ''' Base ImageToText Converter class; all subclasses can only be applied to
+    image and convert to text. '''
+    target = ImageStim
+    _output_type = TextStim

--- a/featurex/converters/video.py
+++ b/featurex/converters/video.py
@@ -1,0 +1,79 @@
+from featurex.stimuli.video import VideoStim, DerivedVideoStim, VideoFrameStim
+from featurex.converters import Converter
+
+import pandas as pd
+
+
+class VideoToDerivedVideoConverter(Converter):
+
+    ''' Base AudioToText Converter class; all subclasses can only be applied to
+    audio and convert to text. '''
+    target = VideoStim
+    _output_type = DerivedVideoStim
+
+
+class FrameSamplingConverter(VideoToDerivedVideoConverter):
+    ''' 
+    Samples frames from video stimuli, to improve efficiency
+
+    Args:
+        every (int): takes every nth frame
+        hertz (int): takes n frames per second
+        num_frames (int): takes top n frames sorted by the absolute difference
+         with the next frame
+    '''
+    def __init__(self, every=None, hertz=None, num_frames=None):
+        self.every = every
+        self.hertz = hertz
+        self.num_frames = num_frames
+
+    def _convert(self, video):
+        if not hasattr(video, "frame_index"):
+            frame_index = range(video.n_frames)
+        else:
+            frame_index = video.frame_index
+        
+        if not hasattr(video, "history"):
+            history = pd.DataFrame(columns=["filter", "value", "n_frames"])
+        else:
+            history = video.history
+
+        if self.every is not None:
+            new_idx = range(video.n_frames)[::self.every]
+            history.loc[history.shape[0]]= ["every", self.every, len(new_idx)]
+        elif self.hertz is not None:
+            interval = int(video.fps / self.hertz)
+            new_idx = range(video.n_frames)[::interval]
+            history.loc[history.shape[0]] = ["hertz", self.hertz, len(new_idx)]
+        elif self.num_frames is not None:
+            import cv2
+            diffs = []
+            for i, img in enumerate(video.frames):
+                if i == 0:
+                    last = img
+                    continue
+                diffs.append(sum(cv2.sumElems(cv2.absdiff(last, img))))
+                last = img
+            new_idx = sorted(range(len(diffs)), key=lambda i: diffs[i], reverse=True)[:self.num_frames]
+            history.loc[history.shape[0]] = ["num_frames", self.num_frames, len(new_idx)]
+
+        frame_index = sorted(list(set(frame_index).intersection(new_idx)))
+
+        # Construct new VideoFrameStim for each frame index
+        onsets = [frame_num * (1. / video.fps) for frame_num in frame_index]
+        elements = []
+        for i, f in enumerate(frame_index):
+            if f != frame_index[-1]:
+                dur = onsets[i+1] - onsets[i]
+            else:
+                dur = (len(video.frames) / video.fps) - onsets[i]
+
+            elem = VideoFrameStim(video=video.clip, frame_num=f,
+                                  duration=dur)
+            elements.append(elem)
+
+        return DerivedVideoStim(filename=video.filename,
+                                elements=elements,
+                                frame_index=frame_index,
+                                history=history)
+        

--- a/featurex/converters/video.py
+++ b/featurex/converters/video.py
@@ -6,8 +6,8 @@ import pandas as pd
 
 class VideoToDerivedVideoConverter(Converter):
 
-    ''' Base AudioToText Converter class; all subclasses can only be applied to
-    audio and convert to text. '''
+    ''' Base VideoToDerivedVideo Converter class; all subclasses can only be
+    applied to video and convert to derived (sampled) video. '''
     target = VideoStim
     _output_type = DerivedVideoStim
 
@@ -19,13 +19,13 @@ class FrameSamplingConverter(VideoToDerivedVideoConverter):
     Args:
         every (int): takes every nth frame
         hertz (int): takes n frames per second
-        num_frames (int): takes top n frames sorted by the absolute difference
+        top_n (int): takes top n frames sorted by the absolute difference
          with the next frame
     '''
-    def __init__(self, every=None, hertz=None, num_frames=None):
+    def __init__(self, every=None, hertz=None, top_n=None):
         self.every = every
         self.hertz = hertz
-        self.num_frames = num_frames
+        self.top_n = top_n
 
     def _convert(self, video):
         if not hasattr(video, "frame_index"):
@@ -45,7 +45,7 @@ class FrameSamplingConverter(VideoToDerivedVideoConverter):
             interval = int(video.fps / self.hertz)
             new_idx = range(video.n_frames)[::interval]
             history.loc[history.shape[0]] = ["hertz", self.hertz, len(new_idx)]
-        elif self.num_frames is not None:
+        elif self.top_n is not None:
             import cv2
             diffs = []
             for i, img in enumerate(video.frames):
@@ -54,8 +54,8 @@ class FrameSamplingConverter(VideoToDerivedVideoConverter):
                     continue
                 diffs.append(sum(cv2.sumElems(cv2.absdiff(last, img))))
                 last = img
-            new_idx = sorted(range(len(diffs)), key=lambda i: diffs[i], reverse=True)[:self.num_frames]
-            history.loc[history.shape[0]] = ["num_frames", self.num_frames, len(new_idx)]
+            new_idx = sorted(range(len(diffs)), key=lambda i: diffs[i], reverse=True)[:self.top_n]
+            history.loc[history.shape[0]] = ["top_n", self.top_n, len(new_idx)]
 
         frame_index = sorted(list(set(frame_index).intersection(new_idx)))
 

--- a/featurex/extractors/image.py
+++ b/featurex/extractors/image.py
@@ -10,7 +10,6 @@ import numpy as np
 import tempfile
 import os
 from warnings import warn
-from PIL import Image
 
 class ImageExtractor(Extractor):
 
@@ -62,21 +61,6 @@ class VibranceExtractor(ImageExtractor):
         data = stim.data
         avg_color = np.var(data, 2).mean()
         return Value(stim, self, {'avg_color': avg_color})
-
-
-class TesseractExtractor(ImageExtractor):
-
-    ''' Uses the Tesseract library to extract text from images '''
-
-    def __init__(self):
-        super(self.__class__, self).__init__()
-
-    def _extract(self, stim):
-        import pytesseract
-        data = stim.data
-        text = pytesseract.image_to_string(Image.fromarray(data))
-
-        return Value(stim, self, {'text': text})
 
 
 class SaliencyExtractor(ImageExtractor):

--- a/featurex/google.py
+++ b/featurex/google.py
@@ -1,0 +1,65 @@
+import base64
+import os
+import tempfile
+from scipy.misc import imsave
+from featurex.core import Transformer
+
+try:
+    from googleapiclient import discovery, errors
+    from oauth2client.client import GoogleCredentials
+except ImportError:
+    pass
+
+
+DISCOVERY_URL = 'https://{api}.googleapis.com/$discovery/rest?version={apiVersion}'
+BATCH_SIZE = 10
+
+
+class GoogleAPITransformer(Transformer):
+
+    def __init__(self, discovery_file=None, api_version='v1', max_results=100,
+                 num_retries=3):
+
+        if discovery_file is None:
+            if 'GOOGLE_APPLICATION_CREDENTIALS' not in os.environ:
+                raise ValueError("No Google application credentials found. "
+                    "A JSON service account key must be either passed as the "
+                    "discovery_file argument, or set in the "
+                    "GOOGLE_APPLICATION_CREDENTIALS environment variable.")
+            discovery_file = os.environ['GOOGLE_APPLICATION_CREDENTIALS']
+
+        self.credentials = GoogleCredentials.from_stream(discovery_file)
+        self.max_results = max_results
+        self.num_retries = num_retries
+        self.service = discovery.build(self.api_name, api_version,
+                                       credentials=self.credentials,
+                                       discoveryServiceUrl=DISCOVERY_URL)
+        super(GoogleAPITransformer, self).__init__()
+
+    def _query_api(self, request):
+        resource = getattr(self.service, self.resource)()
+        request = resource.annotate(body={'requests': request})
+        return request.execute(num_retries=self.num_retries)['responses']
+
+
+class GoogleVisionAPITransformer(GoogleAPITransformer):
+
+    api_name = 'vision'
+    resource = 'images'
+
+    def _build_request(self, stims):
+        request = []
+        for image in stims:
+            temp_file = tempfile.mktemp() + '.png'
+            imsave(temp_file, image.data)
+            img_data = open(temp_file, 'rb').read()
+            content = base64.b64encode(img_data).decode()
+            request.append(
+                {
+                'image': { 'content': content },
+                'features': [{
+                    'type': self.request_type,
+                    'maxResults': self.max_results,
+                }]
+            })
+        return request

--- a/featurex/google.py
+++ b/featurex/google.py
@@ -2,7 +2,7 @@ import base64
 import os
 import tempfile
 from scipy.misc import imsave
-from featurex.core import Transformer
+from featurex.transformers import Transformer
 
 try:
     from googleapiclient import discovery, errors

--- a/featurex/stimuli/video.py
+++ b/featurex/stimuli/video.py
@@ -72,7 +72,7 @@ class DerivedVideoStim(VideoStim):
     VideoStim containing keyframes (for API calls). Each keyframe is associated
     with a duration reflecting the length of its "scene."
     """
-    def __init__(self, filename, elements, frame_index, history):
+    def __init__(self, filename, elements, frame_index=None, history=None):
         super(DerivedVideoStim, self).__init__(filename)
         self.elements = elements
         self.frame_index = frame_index

--- a/featurex/stimuli/video.py
+++ b/featurex/stimuli/video.py
@@ -72,57 +72,13 @@ class DerivedVideoStim(VideoStim):
     VideoStim containing keyframes (for API calls). Each keyframe is associated
     with a duration reflecting the length of its "scene."
     """
-    def __init__(self, filename, **kwargs):
+    def __init__(self, filename, elements, frame_index, history):
         super(DerivedVideoStim, self).__init__(filename)
-        self.history = pd.DataFrame(columns=["filter", "value", "n_frames"])
-        self.tagged_frames = self.frames
-        self.frame_index = range(len(self.frames))
-        self.elements = [VideoFrameStim(self, i, data=f) for i, f in enumerate(self.frames)]
-        self._filter(**kwargs)
+        self.elements = elements
+        self.frame_index = frame_index
+        self.history = history
         
     def __iter__(self):
-        return self.elements.__iter__()
+        for elem in self.elements:
+            yield elem
 
-    def filter(self, **kwargs):
-        self._filter(**kwargs)
-
-    def _filter(self, every=None, hertz=None, num_frames=None):
-        name = "None"
-        thresh = 0
-        if every is not None:
-            name = "every"
-            thresh = every
-            self.frame_index = range(self.n_frames)[::every]
-        elif hertz is not None:
-            name = "hertz"
-            thresh = hertz
-            interval = int(self.fps / hertz)
-            self.frame_index = range(self.n_frames)[::interval]
-        elif num_frames is not None:
-            import cv2
-            name = "num_frames"
-            thresh = num_frames
-            diffs = []
-            for i, img in enumerate(self.frames):
-                if i == 0:
-                    last = img
-                    continue
-                diffs.append(sum(cv2.sumElems(cv2.absdiff(last, img))))
-                last = img
-            self.frame_index = sorted(range(len(diffs)), key=lambda i: diffs[i], reverse=True)[:num_frames]
-        
-        self.tagged_frames = [self.frames[i] for i in self.frame_index]
-        self.history.loc[self.history.shape[0]] = [name, thresh, len(self.tagged_frames)]        
-        
-        onsets = [frame_num * (1. / self.fps) for frame_num in self.frame_index]
-        
-        self.elements = []
-        for i, f in enumerate(self.frame_index):
-            if f != self.frame_index[-1]:
-                dur = onsets[i+1] - onsets[i]
-            else:
-                dur = (len(self.frames) / self.fps) - onsets[i]
-
-            elem = VideoFrameStim(video=self.clip, frame_num=f,
-                                  duration=dur)
-            self.elements.append(elem)

--- a/featurex/tests/test_converters.py
+++ b/featurex/tests/test_converters.py
@@ -1,0 +1,43 @@
+from .utils import get_test_data_path
+from featurex.stimuli.video import VideoStim, VideoFrameStim, DerivedVideoStim
+from featurex.converters.video import FrameSamplingConverter
+import numpy as np
+from os.path import join
+import math
+import pytest
+
+
+def test_derived_video_stim():
+    filename = join(get_test_data_path(), 'video', 'small.mp4')
+    video = VideoStim(filename)
+    assert video.fps == 30
+    assert video.n_frames == 168
+    assert video.width == 560
+
+    # Test frame filters
+    conv = FrameSamplingConverter(every=3)
+    derived = conv.transform(video)
+    assert len(derived.elements) == math.ceil(video.n_frames / 3.0)
+    assert type(next(f for f in derived)) == VideoFrameStim
+    assert next(f for f in derived).duration == 3 * (1 / 30.0)
+
+    # Should refilter from original frames
+    conv = FrameSamplingConverter(hertz=15)
+    derived = conv.transform(derived)
+    assert len(derived.elements) == math.ceil(video.n_frames / 6.0)
+    assert type(next(f for f in derived)) == VideoFrameStim
+    assert next(f for f in derived).duration == 3 * (1 / 15.0)
+
+    # Test filter history
+    assert derived.history.shape == (2, 3)
+    assert np.array_equal(derived.history['filter'], ['every', 'hertz'])
+
+def test_derived_video_stim_cv2():
+    pytest.importorskip('cv2')
+    filename = join(get_test_data_path(), 'video', 'small.mp4')
+    video = VideoStim(filename)
+
+    conv = FrameSamplingConverter(num_frames=5)
+    derived = conv.transform(video)
+    assert len(derived.elements) == 5
+    assert type(next(f for f in derived)) == VideoFrameStim

--- a/featurex/tests/test_converters.py
+++ b/featurex/tests/test_converters.py
@@ -1,10 +1,13 @@
 from os.path import join
 from .utils import get_test_data_path
 from featurex.converters.video import FrameSamplingConverter
-from featurex.converters.api import WitTranscriptionConverter, GoogleSpeechAPIConverter
+from featurex.converters.api import (WitTranscriptionConverter, 
+                                        GoogleSpeechAPIConverter,
+                                        TesseractAPIConverter)
 from featurex.stimuli.video import VideoStim, VideoFrameStim, DerivedVideoStim
 from featurex.stimuli.text import ComplexTextStim
 from featurex.stimuli.audio import AudioStim
+from featurex.stimuli.image import ImageStim
 
 import numpy as np
 import math
@@ -66,3 +69,10 @@ def test_googleAPI_converter():
     text = [elem.text for elem in out_stim]
     assert 'thermodynamics' in text or 'obey' in text
 
+def test_tesseract_converter():
+    pytest.importorskip('pytesseract')
+    image_dir = join(get_test_data_path(), 'image')
+    stim = ImageStim(join(image_dir, 'button.jpg'))
+    conv = TesseractAPIConverter()
+    text = conv.transform(stim).text
+    assert text == 'Exit'

--- a/featurex/tests/test_converters.py
+++ b/featurex/tests/test_converters.py
@@ -45,7 +45,7 @@ def test_derived_video_stim_cv2():
     filename = join(get_test_data_path(), 'video', 'small.mp4')
     video = VideoStim(filename)
 
-    conv = FrameSamplingConverter(num_frames=5)
+    conv = FrameSamplingConverter(top_n=5)
     derived = conv.transform(video)
     assert len(derived.elements) == 5
     assert type(next(f for f in derived)) == VideoFrameStim

--- a/featurex/tests/test_converters.py
+++ b/featurex/tests/test_converters.py
@@ -40,6 +40,7 @@ def test_derived_video_stim():
     assert derived.history.shape == (2, 3)
     assert np.array_equal(derived.history['filter'], ['every', 'hertz'])
 
+
 def test_derived_video_stim_cv2():
     pytest.importorskip('cv2')
     filename = join(get_test_data_path(), 'video', 'small.mp4')
@@ -49,6 +50,7 @@ def test_derived_video_stim_cv2():
     derived = conv.transform(video)
     assert len(derived.elements) == 5
     assert type(next(f for f in derived)) == VideoFrameStim
+
 
 @pytest.mark.skipif("'WIT_AI_API_KEY' not in os.environ")
 def test_witaiAPI_converter():
@@ -60,6 +62,7 @@ def test_witaiAPI_converter():
     text = [elem.text for elem in out_stim]
     assert 'thermodynamics' in text or 'obey' in text
 
+
 @pytest.mark.skipif("'GOOGLE_API_KEY' not in os.environ")
 def test_googleAPI_converter():
     audio_dir = join(get_test_data_path(), 'audio')
@@ -70,6 +73,7 @@ def test_googleAPI_converter():
     text = [elem.text for elem in out_stim]
     assert 'thermodynamics' in text or 'obey' in text
 
+
 def test_tesseract_converter():
     pytest.importorskip('pytesseract')
     image_dir = join(get_test_data_path(), 'image')
@@ -78,6 +82,7 @@ def test_tesseract_converter():
     text = conv.transform(stim).text
     assert text == 'Exit'
 
+
 @pytest.mark.skipif("'GOOGLE_APPLICATION_CREDENTIALS' not in os.environ")
 def test_google_vision_api_text_converter():
     conv = GoogleVisionAPITextConverter(num_retries=5)
@@ -85,3 +90,8 @@ def test_google_vision_api_text_converter():
     stim = ImageStim(filename)
     text = conv.transform(stim).text
     assert 'Exit' in text
+    
+    conv = GoogleVisionAPITextConverter(handle_annotations='concatenate')
+    text = conv.transform(stim).text
+    assert 'Exit' in text
+

--- a/featurex/tests/test_converters.py
+++ b/featurex/tests/test_converters.py
@@ -4,6 +4,7 @@ from featurex.converters.video import FrameSamplingConverter
 from featurex.converters.api import (WitTranscriptionConverter, 
                                         GoogleSpeechAPIConverter,
                                         TesseractAPIConverter)
+from featurex.converters.google import GoogleVisionAPITextConverter
 from featurex.stimuli.video import VideoStim, VideoFrameStim, DerivedVideoStim
 from featurex.stimuli.text import ComplexTextStim
 from featurex.stimuli.audio import AudioStim
@@ -76,3 +77,11 @@ def test_tesseract_converter():
     conv = TesseractAPIConverter()
     text = conv.transform(stim).text
     assert text == 'Exit'
+
+@pytest.mark.skipif("'GOOGLE_APPLICATION_CREDENTIALS' not in os.environ")
+def test_google_vision_api_text_converter():
+    conv = GoogleVisionAPITextConverter(num_retries=5)
+    filename = join(get_test_data_path(), 'image', 'button.jpg')
+    stim = ImageStim(filename)
+    text = conv.transform(stim).text
+    assert 'Exit' in text

--- a/featurex/tests/test_extractors.py
+++ b/featurex/tests/test_extractors.py
@@ -8,7 +8,6 @@ from featurex.extractors.audio import STFTExtractor, MeanAmplitudeExtractor
 from featurex.extractors.image import (BrightnessExtractor,
                                         SharpnessExtractor,
                                         VibranceExtractor,
-                                        TesseractExtractor,
                                         SaliencyExtractor)
 from featurex.extractors.video import DenseOpticalFlowExtractor
 from featurex.extractors.api import (IndicoAPIExtractor,
@@ -106,14 +105,6 @@ def test_vibrance_extractor():
     val = stim.extract([VibranceExtractor()])
     color = val.data['VibranceExtractor'].data['avg_color']
     assert np.isclose(color,1370.65482988)
-
-def test_tesseract_extractor():
-    pytest.importorskip('pytesseract')
-    image_dir = join(get_test_data_path(), 'image')
-    stim = ImageStim(join(image_dir, 'button.jpg'))
-    ext = TesseractExtractor()
-    output = ext.transform(stim).data['text']
-    assert output == 'Exit'
 
 def test_saliency_extractor():
     pytest.importorskip('cv2')

--- a/featurex/tests/test_google_extractors.py
+++ b/featurex/tests/test_google_extractors.py
@@ -1,6 +1,5 @@
 from featurex.extractors.google import (GoogleVisionAPIExtractor,
                                         GoogleVisionAPIFaceExtractor,
-                                        GoogleVisionAPITextExtractor,
                                         GoogleVisionAPILabelExtractor,
                                         GoogleVisionAPIPropertyExtractor)
 from featurex.stimuli.image import ImageStim
@@ -46,16 +45,6 @@ def test_google_vision_api_face_extractor_inits():
     assert isinstance(values, Value)
     assert values.data['rollAngle'] == -1.6712251
     assert values.data['angerLikelihood'] == "VERY_UNLIKELY"
-
-@pytest.mark.skipif("'GOOGLE_APPLICATION_CREDENTIALS' not in os.environ")
-def test_google_vision_api_text_extractor():
-    ext = GoogleVisionAPITextExtractor(num_retries=5)
-    filename = join(get_test_data_path(), 'image', 'button.jpg')
-    stim = ImageStim(filename)
-    values = ext.transform(stim)[0]
-    assert values.data['locale'] == 'en'
-    assert 'Exit' in values.data['description']
-    assert np.isfinite(values.data['boundingPoly_vertex2_y'])
 
 @pytest.mark.skipif("'GOOGLE_APPLICATION_CREDENTIALS' not in os.environ")
 def test_google_vision_api_label_extractor():

--- a/featurex/tests/test_stims.py
+++ b/featurex/tests/test_stims.py
@@ -1,5 +1,5 @@
 from .utils import get_test_data_path
-from featurex.stimuli.video import VideoStim, VideoFrameStim, DerivedVideoStim
+from featurex.stimuli.video import VideoStim, VideoFrameStim
 from featurex.stimuli.text import ComplexTextStim
 from featurex.stimuli.audio import AudioStim
 from featurex.stimuli.image import ImageStim
@@ -10,7 +10,6 @@ from featurex.support.download import download_nltk_data
 import numpy as np
 from os.path import join
 import pandas as pd
-import math
 import pytest
 
 
@@ -58,6 +57,7 @@ def test_image_stim(dummy_iter_extractor):
     values = stim.extract([dummy_iter_extractor])
     assert isinstance(values, Value)
 
+
 def test_video_stim():
     ''' Test VideoStim functionality. '''
     filename = join(get_test_data_path(), 'video', 'small.mp4')
@@ -73,39 +73,6 @@ def test_video_stim():
     assert isinstance(f, VideoFrameStim)
     assert isinstance(f.onset, float)
     f.data.shape == (320, 560, 3)
-
-def test_derived_video_stim():
-    ''' Test DerivedVideoStim functionality. '''
-    filename = join(get_test_data_path(), 'video', 'small.mp4')
-    video = DerivedVideoStim(filename)
-    assert video.fps == 30
-    assert video.n_frames == 168
-    assert video.width == 560
-
-    # Test frame filters
-    video.filter(every=3)
-    assert len(video.elements) == math.ceil(video.n_frames / 3.0)
-    assert type(next(f for f in video)) == VideoFrameStim
-    assert next(f for f in video).duration == 3 * (1 / 30.0)
-
-    # Should refilter from original frames
-    video.filter(hertz=15)
-    assert len(video.elements) == math.ceil(video.n_frames / 2.0)
-    assert type(next(f for f in video)) == VideoFrameStim
-    assert next(f for f in video).duration == 1 * (1 / 15.0)
-
-    # Test filter history
-    assert video.history.shape == (3, 3)
-    assert np.array_equal(video.history['filter'], ['None', 'every', 'hertz'])
-
-def test_derived_video_stim_cv2():
-    pytest.importorskip('cv2')
-    filename = join(get_test_data_path(), 'video', 'small.mp4')
-    video = DerivedVideoStim(filename)
-
-    video.filter(num_frames=5)
-    assert len(video.elements) == 5
-    assert type(next(f for f in video)) == VideoFrameStim
 
 def test_audio_stim(dummy_iter_extractor):
     audio_dir = join(get_test_data_path(), 'audio')


### PR DESCRIPTION
(1) Moved `DerivedVideoStim` `filter` functionality to a `FrameSamplingConverter`
(2) Moved `TesseractAPIExtractor` to a `TesseractAPIConverter` which inherits `ImageToTextConverter`
(3) Moved `GoogleVisionAPITextExtractor` to `GoogleVisionAPITextConverter` which also inherits `ImageToTextConverter` and required (4)
(4) Refactored core GoogleAPI interaction (working with credentials, executing requests, building requests for the Vision API) to a package-wide `GoogleAPITransformer` class, which can be subclassed by both `Extractors` and `Converters`. 
