### PR TITLE
Propagate stimulus name during conversion

### DIFF
--- a/featurex/converters/__init__.py
+++ b/featurex/converters/__init__.py
@@ -9,7 +9,12 @@ class Converter(with_metaclass(ABCMeta, Transformer)):
     ''' Base class for Converters.'''
 
     def convert(self, stim, *args, **kwargs):
-        return self._convert(stim, *args, **kwargs)
+        new_stim = self._convert(stim, *args, **kwargs)
+        if new_stim.id is None:
+            new_stim.name = stim.name
+        else:
+            new_stim.name = stim.name + '_' + new_stim.id
+        return new_stim
 
     @abstractmethod
     def _convert(self, stim):

--- a/featurex/converters/__init__.py
+++ b/featurex/converters/__init__.py
@@ -10,10 +10,10 @@ class Converter(with_metaclass(ABCMeta, Transformer)):
 
     def convert(self, stim, *args, **kwargs):
         new_stim = self._convert(stim, *args, **kwargs)
-        if new_stim.id is None:
+        if new_stim.name is None:
             new_stim.name = stim.name
         else:
-            new_stim.name = stim.name + '_' + new_stim.id
+            new_stim.name = stim.name + '_' + new_stim.name
         return new_stim
 
     @abstractmethod

--- a/featurex/converters/api.py
+++ b/featurex/converters/api.py
@@ -85,8 +85,8 @@ class IBMSpeechAPIConverter(AudioToTextConverter):
         timestamps = result['results'][0]['alternatives'][0]['timestamps']
         elements = []
         for i, entry in enumerate(timestamps):
-            elements.append(DynamicTextStim(text=entry[0], onset=entry[1],
-                                                duration=entry[2]-entry[1]))
+            elements.append(TextStim(text=entry[0], onset=entry[1],
+                                    duration=entry[2]-entry[1]))
         
         return ComplexTextStim(elements=elements)
 
@@ -118,9 +118,9 @@ class IBMSpeechAPIConverter(AudioToTextConverter):
         try:
             response = urlopen(request, timeout=None)
         except HTTPError as e:
-            raise RequestError("recognition request failed: {0}".format(getattr(e, "reason", "status {0}".format(e.code))))
+            raise Exception("recognition request failed: {0}".format(getattr(e, "reason", "status {0}".format(e.code))))
         except URLError as e:
-            raise RequestError("recognition connection failed: {0}".format(e.reason))
+            raise Exception("recognition connection failed: {0}".format(e.reason))
         
         response_text = response.read().decode("utf-8")
         result = json.loads(response_text)

--- a/featurex/stimuli/__init__.py
+++ b/featurex/stimuli/__init__.py
@@ -11,14 +11,16 @@ class Stim(with_metaclass(ABCMeta)):
     def __init__(self, filename=None, onset=None, duration=None):
 
         self.filename = filename
+        self.name = basename(filename) if filename is not None else self.id
         self.features = []
         self.onset = onset
         self.duration = duration
 
+
     @property
-    def name(self):
+    def id(self):
         filename = self.filename
-        return basename(filename)if filename is not None else self.id
+        return basename(filename) if filename is not None else None
 
 
 class CollectionStimMixin(with_metaclass(ABCMeta)):

--- a/featurex/stimuli/__init__.py
+++ b/featurex/stimuli/__init__.py
@@ -19,8 +19,7 @@ class Stim(with_metaclass(ABCMeta)):
 
     @property
     def id(self):
-        filename = self.filename
-        return basename(filename) if filename is not None else None
+        return ''
 
 
 class CollectionStimMixin(with_metaclass(ABCMeta)):

--- a/featurex/stimuli/text.py
+++ b/featurex/stimuli/text.py
@@ -12,7 +12,7 @@ class TextStim(Stim):
     ''' Any simple text stimulus--most commonly a single word. '''
 
     def __init__(self, filename=None, text=None, onset=None, duration=None):
-        if filename is not None:
+        if filename is not None and text is None:
             text = open(filename).read()
         self.text = text
         super(TextStim, self).__init__(filename, onset, duration)

--- a/featurex/stimuli/text.py
+++ b/featurex/stimuli/text.py
@@ -19,7 +19,7 @@ class TextStim(Stim):
 
 
     @property
-    def name(self):
+    def id(self):
         return self.text
 
 

--- a/featurex/stimuli/text.py
+++ b/featurex/stimuli/text.py
@@ -20,7 +20,10 @@ class TextStim(Stim):
 
     @property
     def id(self):
-        return self.text
+        if self.filename is not None:
+            return self.filename + '_' + self.text
+        else:
+            return self.text
 
 
 class ComplexTextStim(Stim, CollectionStimMixin):
@@ -60,6 +63,8 @@ class ComplexTextStim(Stim, CollectionStimMixin):
             else:
                 self._from_file(filename, columns, default_duration)
 
+        super(ComplexTextStim, self).__init__(filename, onset, duration)
+
     def _from_file(self, filename, columns, default_duration):
         tod_names = {'t': 'text', 'o': 'onset', 'd': 'duration'}
 
@@ -78,7 +83,7 @@ class ComplexTextStim(Stim, CollectionStimMixin):
                 duration = r.get('duration', None)
                 if duration is None:
                     duration = default_duration
-                elem = TextStim(None, r['text'], r['onset'], duration)
+                elem = TextStim(filename, r['text'], r['onset'], duration)
             self.elements.append(elem)
 
     def _from_srt(self, filename):
@@ -101,7 +106,7 @@ class ComplexTextStim(Stim, CollectionStimMixin):
         df = pd.DataFrame(columns=["text", "onset", "duration"], data=list_)
 
         for i, r in df.iterrows():
-            elem = TextStim(None, r['text'], r['onset'], r["duration"])
+            elem = TextStim(filename, r['text'], r['onset'], r["duration"])
             self.elements.append(elem)
 
     def __iter__(self):

--- a/featurex/stimuli/video.py
+++ b/featurex/stimuli/video.py
@@ -20,6 +20,11 @@ class VideoFrameStim(ImageStim):
         super(VideoFrameStim, self).__init__(filename, onset, duration, data)
 
 
+    @property
+    def id(self):
+        return self.frame_num
+
+
 class VideoStim(Stim, CollectionStimMixin):
 
     ''' A video. '''

--- a/featurex/stimuli/video.py
+++ b/featurex/stimuli/video.py
@@ -22,7 +22,7 @@ class VideoFrameStim(ImageStim):
 
     @property
     def id(self):
-        return self.frame_num
+        return self.video.name + '_' + str(self.frame_num)
 
 
 class VideoStim(Stim, CollectionStimMixin):

--- a/featurex/tests/test_graph.py
+++ b/featurex/tests/test_graph.py
@@ -73,6 +73,7 @@ def test_small_pipeline():
     nodes = [(TesseractConverter(), 'tesseract', 
                 [(LengthExtractor(), 'length')])]
     graph = Graph(nodes)
-    result = graph.extract([stim])[0].to_df()
-    assert 'text_length' in result.columns
-    assert result['text_length'][0] == 4
+    result = graph.extract([stim])
+    assert (0, 'button.jpg_Exit') in result.index
+    assert ('LengthExtractor', 'text_length') in result.columns
+    assert result[('LengthExtractor', 'text_length')].values[0] == 4


### PR DESCRIPTION
When a stimulus is converted into another, tack on source information to the new stimulus.
Implemented with this in mind:
-`name` property holds what the stimulus should be called in an `ExtractorResult`
-`id` property holds a unique identifier for a stimulus, typically for those belonging to a `CollectionStimMixin`

There was some overlap with #80 but I don't think there will be any merge conflicts.