### PR TITLE
Caching conversions

### DIFF
--- a/featurex/converters/__init__.py
+++ b/featurex/converters/__init__.py
@@ -1,12 +1,21 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
 from featurex.transformers import Transformer, CollectionStimMixin
 from six import with_metaclass
+from tempfile import mkdtemp
+from joblib import Memory
+
+cachedir = mkdtemp()
+memory = Memory(cachedir=cachedir, verbose=0)
 
 __all__ = ['api', 'audio', 'google', 'image', 'video']
 
 
 class Converter(with_metaclass(ABCMeta, Transformer)):
     ''' Base class for Converters.'''
+
+    def __init__(self):
+        super(Converter, self).__init__()
+        self.convert = memory.cache(self.convert)
 
     def convert(self, stim, *args, **kwargs):
         new_stim = self._convert(stim, *args, **kwargs)

--- a/featurex/converters/api.py
+++ b/featurex/converters/api.py
@@ -82,6 +82,7 @@ class IBMSpeechAPIConverter(AudioToTextConverter):
     '''
 
     def __init__(self, username=None, password=None):
+        super(IBMSpeechAPIConverter, self).__init__()
         import speech_recognition as sr
         if username is None or password is None:
             try:

--- a/featurex/converters/video.py
+++ b/featurex/converters/video.py
@@ -16,7 +16,7 @@ class VideoToAudioConverter(Converter):
     def __init__(self, fps=44100, nbytes=2,
                     buffersize=2000, bitrate=None,
                     ffmpeg_params=None):
-        super(self.__class__, self).__init__()
+        super(VideoToAudioConverter, self).__init__()
         self.fps = fps
         self.nbytes = nbytes
         self.buffersize = buffersize
@@ -50,6 +50,7 @@ class FrameSamplingConverter(VideoToDerivedVideoConverter):
          with the next frame
     '''
     def __init__(self, every=None, hertz=None, top_n=None):
+        super(FrameSamplingConverter, self).__init__()
         self.every = every
         self.hertz = hertz
         self.top_n = top_n


### PR DESCRIPTION
Somewhat addresses #91 but it currently fails.

The problem with memoizing via joblib: we can’t pickle conversions of `VideoStim`s because pickling requires serializing `VideoClip`s which requires serializing `AudioClip`s. This doesn't work since `AudioClip`s have the property `make_frame` which is a lambda function. Unfortunately `pickle` does not like lambdas. This may be solved by using `dill`, but joblib seems to have stalled at implementing this (see https://github.com/joblib/joblib/pull/240).

There may be workarounds for this, or we can explore other caching libraries.